### PR TITLE
Adding documentation content for manage, register, retrieve and share

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -61,3 +61,12 @@ To obtain a Data Hub:
 1. **Register** interest in a Data Hub. Here a prospective coordinator completes a registration form. This will include questions related to what the Data Hub will be used for and how many users would be associated with it. Once approved, a Data Hub is assigned and the prospective coordinator can move on to the next step.
 2. **Setup** the Data Hub. The coordinator must include descriptions of the Data Hub and link users to the Data Hub. Users will automatically receive credentials.
 3. **Use** the Data Hub. Fig.1 expands on this stage for an example use-case. Overall data can be linked (at the ENA Project level) to the Data Hub, and therefore associated users. Data can also be queried and retrieved once linked to the Data Hub.
+
+.. toctree::
+    :caption: ENA Data Hub Usage
+    :maxdepth: 1
+
+    register
+    manage
+    share
+    retrieval

--- a/docs/source/manage.rst
+++ b/docs/source/manage.rst
@@ -1,0 +1,31 @@
+===================
+Data Hub Management
+===================
+
+This page provides specific guidance to coordinators of Data Hubs. As the coordinator of an ENA Data Hub, you have control over many settings, which can be managed through the `ENA Data Hubs Portal <https://www.ebi.ac.uk/ena/datahubs/>`_.
+
+After logging into the Data Hubs Portal, navigate to the ‘Manage’ tab (or click on the ‘My Data Hubs’ card). Here you will be presented with a list of Data Hubs that you are associated with.
+
+Where you have coordinator permissions on a Data Hub, you will see an edit icon in the ‘Action’ column (figure 1).
+
+.. image:: images/datahubs_manage.png
+   :align: center
+**Figure 1**. ‘Manage’ tab view displaying Data Hubs associated with your login. The edit menu highlighted by green arrows indicates which data hubs you have coordinator privileges for.
+
+From these menus, you can begin to manage your Data Hub settings:
+* **General**: view Data Hub names/topic, add display name, or update description
+* **Users**: view and add users, and update their roles
+
+.. image:: images/datahubs_general_manage.png
+   :align: center
+**Figure 2**. Data Hub management ‘General’ submenu. Basic Data Hub information can be seen and edited here.
+
+----------------
+Coordinator Role
+----------------
+By requesting a new Data Hub, a coordinator agrees to handle overall management of the Data Hub. This includes, and is not limited to:
+* Providing appropriate Data Hub or data descriptions.
+* Managing what users are added or removed from the Data Hub.
+* Defining user roles for the Data Hub.
+* Being the main point of contact for ENA regarding the Data Hub.
+* Being the main point of contact for users of the Data Hub.

--- a/docs/source/register.rst
+++ b/docs/source/register.rst
@@ -1,0 +1,15 @@
+==========================
+Registering for a Data Hub
+==========================
+
+To obtain a Data Hub, a user must register interest, via the form on the `Data Hubs Portal <https://www.ebi.ac.uk/ena/datahubs/request-datahub#request-data-hub>`_. This is to be completed by a coordinator of the Data Hub.
+
+For a request, the coordinator must have a valid Webin account (e.g. Webin-XXXXX). To register for a Webin account, see here: <https://www.ebi.ac.uk/ena/submit/webin/login>. Coordinators must also provide their name, email address (preferably institutional), affiliation, and information about the prospective Data Hub. This includes an estimate for the number of users, how long it is required for, and the overall reason for request.
+
+Once a coordinator submits the request, the ENA’s support team is notified and will assess the request, prior to assigning the Data Hub (if approved), within 2 working days.
+
+The registration form enables the ENA to better understand the requirement for a Data Hub. This will be used by the ENA’s support team to approve a request. Aspects that are taken into consideration include:
+* The length of time that the Data Hub would be required for.
+* The number of data providers and consumers there will be for the Data Hub.
+* The number of institutes and their geographic spread.
+* The volume of data to be shared and their frequency/regularity.

--- a/docs/source/retrieval.rst
+++ b/docs/source/retrieval.rst
@@ -1,0 +1,73 @@
+====================
+Search and Retrieval
+====================
+
+This page details instructions to search and retrieve data shared to the ENA Data Hubs. This builds on the ENA’s General Guide on `ENA Data Retrieval <https://ena-docs.readthedocs.io/en/latest/retrieval/general-guide.html>`_. Searching data involves creating queries to view matching data records. This is separate to retrieval which includes methods to download data records. Both have been described below.
+
+.. note::
+    💡  Search and retrieval is carried out using **Data Hub credentials, e.g. dcc_XXXX**.
+
+--------------
+Searching Data
+--------------
+The ENA Data Hubs enable users to search data:
+* Interactively through Advanced Search in the ENA Data Hubs Portal.
+* Programmatically through the ENA Portal API.
+
+Both methods enable users to search across public and their own private (pre-release) data, either separately or in combination. In order to later download data, ensure that search results include fields related to file download links (e.g. ‘submitted_ftp’ or ‘fastq_ftp’).
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Interactive Advanced Search
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Advanced Search can be found here: https://www.ebi.ac.uk/ena/datahubs/search. If you would like to view any pre-release data, ensure that you have logged in with Data Hub credentials - e.g. dcc_XXXX.
+
+You must specify a ‘Data Type’ prior to structuring the query. For more information on Advanced Search, including how to structure your queries, see detailed documentation here: https://ena-docs.readthedocs.io/en/latest/retrieval/advanced-search.html.
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Programmatic ENA Portal API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+There is a `Swagger interface <https://www.ebi.ac.uk/ena/portal/api/swagger-ui/index.html>`_ detailing all of the available endpoints and their options, but most users will use the /search endpoint. For complete documentation on the Portal API, see `here <https://docs.google.com/document/d/1CwoY84MuZ3SdKYocqssumghBF88PWxUZ/edit?tab=t.0>`_.
+
+^^^^^^^^^^^^^^^^^^
+Query Construction
+^^^^^^^^^^^^^^^^^^
+Many different types of data and fields can be queried using the Portal API. To help to construct your query, you can use `Advanced Search <https://www.ebi.ac.uk/ena/datahubs/search>`_. From here, you can select different data types, construct data filters, set result limits and select custom field sets. Once you have made your selections, click on the ‘Copy Curl Request’ button at the bottom right of the screen. This will provide users with a command without authentication, which you can modify to add Data Hub settings and authentication.
+
+Paste your `curl` command into an editor. We will need to add some extra fields to the query to ensure it fetches data from your Data Hub:
+1. Append the following to the `-d` section of your command:
+.. code-block::
+    &dataPortal=ena&dccDataOnly=true&limit=0
+2. At the end of the command, add authentication using the `-u` flag:
+.. code-block::
+    -u 'dcc_user:dcc_password'
+
+.. note::
+    💡  Use limit=0 to return all results
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Search Data Hub Records Only
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To view only Data Hub records, ensure that you specify to view Data Hub records only. In Advanced Search, this is specified through the toggle under section 5 - ‘Data Filters’, as shown in fig.1. Alternatively through ENA Portal API, specify `dccDataOnly=true` in your query, an example to fetch all raw read data held in a Data Hub has been included below.
+
+.. image:: images/datahub_advanced_search.png
+   :align: center
+**Figure 1**. Section 5 (‘Data Filters’) in Advanced Search in the Data Hubs Portal. This presents a toggle regarding whether a user would like to see only Data Hub records, or view Data Hub records alongside any public ENA records that match the overall query.
+
+.. code-block::
+    curl -X POST -H "Content-Type: application/x-www-form-urlencoded" \
+        -d 'result=read_run&fields=run_accession%2Cstudy_accession%2Cfastq_ftp&dataPortal=ena&dccDataOnly=true&limit=0' \
+        "https://www.ebi.ac.uk/ena/portal/api/search" \
+        -u 'dcc_user:dcc_password'
+
+---------------
+Retrieving Data
+---------------
+To retrieve data, users must do so programmatically. File download links from search results (see Searching Data above) enable you to choose from a few methods in order to fetch the data files using the links. These include (but are not limited to):
+1. `wget` example:
+.. code-block::
+    wget --ftp-user=dcc_name --ftp-password=dcc_password \
+    ftp://ftp.dcc-private.ebi.ac.uk/vol1/…
+2. `curl` example:
+.. code-block::
+    curl -u 'dcc_user:dcc_password' -O \
+    "ftp://ftp.dcc-private.ebi.ac.uk/vol1/fastq/..."

--- a/docs/source/share.rst
+++ b/docs/source/share.rst
@@ -1,0 +1,37 @@
+============
+Sharing Data
+============
+
+This page describes how to share (or link) data to a Data Hub. This is controlled at the ENA project level (e.g. PRJXXXX) and can only be carried out by data providers or coordinators. By sharing or linking data to a Data Hub, the data provider or coordinator has agreed to share data amongst all users associated with the Data Hub.
+
+.. note::
+    💡 Data sharing is carried out using **ENA Webin credentials, e.g. Webin-XXXXX**.
+
+---------------------
+Create ENA Project(s)
+---------------------
+A project groups together data submitted to the archive and controls its release date and Data Hubs linkage. If you have not already done so, please follow our documentation on how to register projects: https://ena-docs.readthedocs.io/en/latest/submit/study.html.
+
+.. note::
+    💡  Existing projects can also retrospectively be linked to a Data Hub. All contents of these projects will become available through the Data Hub.
+
+-------------------------
+Link Projects to Data Hub
+-------------------------
+Once projects have been created, data providers can link them to the relevant Data Hubs through the Data Hubs Portal. Linking a project automatically makes everything submitted to this project available to your fellow Data Hub users.
+
+The linking action is performed in the ‘Manage’ menu under the ‘Link data to Data Hubs’ sub-tab using a checkbox matrix (fig. 1).
+
+.. warning::
+    Note: It can take 1-3 days for data from a newly-linked project to be retrievable from a Data Hub.
+
+----------------------
+Submit Data to Project
+----------------------
+To make data available through a Data Hub, simply submit it to your linked project(s). For a general guide on submission to ENA, please refer to https://ena-docs.readthedocs.io/en/latest/submit/general-guide.html. It is best to familiarise yourself with the `ENA Metadata Model <https://ena-docs.readthedocs.io/en/latest/submit/general-guide/metadata.html>`_, as the Data Hubs make use of this through the linking of projects.
+
+For further queries, please contact us at ena-data-hubs@ebi.ac.uk.
+
+.. image:: images/link_data.png
+   :align: center
+**Figure 1**. Checkbox matrix for linking projects to Data Hubs. Projects are represented as rows and Data Hub names are shown as columns.


### PR DESCRIPTION
This PR includes the addition of pages related to Data Hub:

- Registration
- Management
- Sharing
- Retrieval

The index was also updated to include links to these pages from the homepage.